### PR TITLE
Allow extra attributes be added `Token` and `Document` wise

### DIFF
--- a/nlpiper/core/document.py
+++ b/nlpiper/core/document.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, Extra
 
 from nlpiper.logger import log
 
@@ -36,6 +36,7 @@ class Token(BaseModel):
 
     class Config:
         validate_assignment = True
+        extra = Extra.allow
 
 
 class Document(BaseModel):
@@ -57,3 +58,4 @@ class Document(BaseModel):
 
     class Config:
         validate_assignment = True
+        extra = Extra.allow


### PR DESCRIPTION
## :pencil: Changelog:

- :sparkles: Features:
   - Allow extra attributes be added `Token` and `Document` wise